### PR TITLE
only verify whether list exists when creating rules

### DIFF
--- a/pkg/storage/rulestorage/redis_create.go
+++ b/pkg/storage/rulestorage/redis_create.go
@@ -22,24 +22,24 @@ func (r *Redis) Create(inp []*Object) ([]*Object, error) {
 			}
 		}
 
-		var key []string
+		var key string
 		{
-			key = append(Slicer([]*Object{inp[i]}).Rsrc(), lisObj(inp[i].List))
+			key = lisObj(inp[i].List)
 		}
 
 		var cou int64
 		{
-			cou, err = r.red.Simple().Exists().Multi(key...)
+			cou, err = r.red.Simple().Exists().Multi(key)
 			if simple.IsNotFound(err) {
-				return nil, tracer.Maskf(resourceObjectNotFoundError, "%#v", key)
+				return nil, tracer.Maskf(listObjectNotFoundError, "%#v", key)
 			} else if err != nil {
 				return nil, tracer.Mask(err)
 			}
 		}
 
 		// Ensure all of the referenced resource objects do in fact exist.
-		if cou != int64(len(key)) {
-			return nil, tracer.Maskf(resourceObjectNotFoundError, "%#v", key)
+		if cou != 1 {
+			return nil, tracer.Maskf(listObjectNotFoundError, "%#v", key)
 		}
 
 		var now time.Time

--- a/pkg/storage/rulestorage/redis_error.go
+++ b/pkg/storage/rulestorage/redis_error.go
@@ -4,9 +4,9 @@ import (
 	"github.com/xh3b4sd/tracer"
 )
 
-var resourceObjectNotFoundError = &tracer.Error{
-	Kind: "resourceObjectNotFoundError",
-	Desc: "The request expects all resource objects referenced in the rule object to exist. Not all of the resource objects referenced in the rule object were found to exist. Therefore the request failed.",
+var listObjectNotFoundError = &tracer.Error{
+	Kind: "listObjectNotFoundError",
+	Desc: "The request expects list object referenced in the rule object to exist. The list object referenced in the rule object was not found to exist. Therefore the request failed.",
 }
 
 var ruleObjectNotFoundError = &tracer.Error{

--- a/pkg/storage/rulestorage/slicer.go
+++ b/pkg/storage/rulestorage/slicer.go
@@ -58,19 +58,6 @@ func (s Slicer) Like() []objectid.ID {
 	return use
 }
 
-// Rsrc returns the storage keys pointing to the event IDs meant to be excluded
-// and included in the list associated to the underlying rules.
-func (s Slicer) Rsrc() []string {
-	var res []string
-
-	for _, x := range s {
-		res = append(res, objectid.Fmt(x.Excl, x.KeyFmt())...)
-		res = append(res, objectid.Fmt(x.Incl, x.KeyFmt())...)
-	}
-
-	return res
-}
-
 func (s Slicer) Rule() []objectid.ID {
 	var ids []objectid.ID
 


### PR DESCRIPTION
When we added the rule endpoints we also added verification for the existence of the referenced list and other resources. It turns out we cannot really tell whether the resources desired in the created rules do definitely already exist. A rule may express to add all events for users who create events. This rule should be valid, whether the referenced user object did already create an event or not. Many users may never create events. Regardless, anyone should be able to follow people in case they do eventually. 